### PR TITLE
added alla project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "alla"]
+	path = alla
+	url = git@bitbucket.org:paly627/alla.git


### PR DESCRIPTION
Pridal som svoj projekt ako submodule. Zatial ho mam len na bitbuckete.
Ked si to mergnes, tak nasledovnym prikazom by sa mal stiahnut moj projekt do adresara alla a mal by sa dat otestovat tvojim testovacom:

git submodule update --init

Zmeny oproti povodnej specifikacii:
- chybaju tuples, mnoziny, dicty, dynamicke typovanie
* typ je bud explicitne uvedeny alebo odvodeny z priradeneho vyrazu
+ typ premennej moze byt zmeneny v podbloku pouzitim klucoveho slova var
+ viazrozmerne polia, viacrozmerne podpolia, porovnavanie poli (rovnost, nerovnost)
+ ak v prikaze 'break n' je n > ako pocet vnorenych cyklov, tak vyhodi vynimku pri kompilacii
+ v kode sa nesmu pouzivat TAB znaky a kod musi byt ukonceny NEWLINE-om
+ volanie funkcie pred deklaraciou (dvojprechodovy kompilator - v prvom prechode vytvori scope-y a deklarauje funkcie, v druhom prechode zvysok)
+ definicie funkcii v tele inych funkcii (funkcie a scope-y su spravene podobne ako v DU3)
+ funkcia nemusi mat definovany typ (defaultne je int)
+ pridany 'pass' statement (podobny vyznam ako v pythone)
- chyba read_bool()
+ read_float(), println()
- hodnota premennej nie je 'none' by default, ale zvykne byt 0/0.0/prazdny string; v poliach je hodnota jednotlivych elementov nedefinovana (nahodna) --> preto nefunguju zretazenia rozne velkych poli stringov
- chyba operator 'is'
+ polia musia byt deklarovane s velkostou jednotlivych dimenzii (lubovolny expression)
+ ak je pole deklarovane priradenim, tak nesmie mat explicitne uvedeny typ (typ aj velkost pola sa odvodi)
* argumenty funkcie musia mat uvedeny typ, ak je to pole, tak nesmie mat uvedenu velkost dimenzii v type
- one-linery nemusia byt oddelene prave 2 medzerami
+ indent moze mat lubovolnu dlzku
+ ine?